### PR TITLE
Add good_cert column to domains

### DIFF
--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -55,10 +55,6 @@ $(function () {
           data: "totals.crypto.good_cert",
           render: Tables.percentTotals("crypto", "good_cert")
         },
-        // {
-        //   data: "https.preloaded",
-        //   render: display(names.preloaded[language])
-        // },
         {
           data: "",
           render: Tables.noop

--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -52,9 +52,13 @@ $(function () {
           render: Tables.percentTotals("crypto", "bod_crypto")
         },
         {
-          data: "https.preloaded",
-          render: display(names.preloaded[language])
+          data: "totals.crypto.good_cert",
+          render: Tables.percentTotals("crypto", "good_cert")
         },
+        // {
+        //   data: "https.preloaded",
+        //   render: display(names.preloaded[language])
+        // },
         {
           data: "",
           render: Tables.noop
@@ -189,20 +193,18 @@ $(function () {
       }
     },
 
-    // Parent domains only
-    preloaded: {
+    good_cert: {
       en: {
-        0: "No",  // No
-        1: "Ready",  // Preload-ready
-        2: "<strong>Yes</strong>"  // Yes
+        "-1": "<strong>No</strong>",
+        0: "<strong>No</strong>",
+        1: "Yes",
       },
       fr: {
-        0: "Non", 
-        1: "Prêt", 
-        2: "<strong>Yes</strong>"
+        "-1": "<strong>Non</strong>",
+        0: "<strong>Non</strong>",
+        1: "Oui",
       }
-    },
-
+    }
   };
 
   var display = function(set) {
@@ -260,6 +262,9 @@ $(function () {
 
       var crypto = displayCrypto(host);
       details.append($("<td/>").html(crypto));
+
+      var good_cert = names.good_cert[language][host.https.good_cert];
+      details.append($("<td/>").html(good_cert));
 
       // blank
       details.append($("<td/>"));

--- a/track/templates/en/domains.html
+++ b/track/templates/en/domains.html
@@ -31,7 +31,7 @@
 	          <th class="min-tablet">Enforces HTTPS</th>
 	          <th class="min-tablet">HSTS</th>
 	          <th class="min-tablet-l">Free of RC4/3DES and SSLv2/SSLv3</th>
-	          <th class="min-tablet-l">Preloaded</th>
+	          <th class="min-tablet-l">Uses approved certificates</th>
 	          <th class="none" scope="col"></th>
 	        </tr>
 	      </thead>

--- a/track/templates/fr/domains.html
+++ b/track/templates/fr/domains.html
@@ -31,7 +31,7 @@
 	          <th class="min-tablet">Applique le protocole HTTPS</th>
 	          <th class="min-tablet">HSTS</th>
 	          <th class="min-tablet-l">RC4/3DES et SSLv2/SSLv3 non utilisés</th>
-	          <th class="min-tablet-l">Domaines préchargés</th>
+	          <th class="min-tablet-l">Uses approved certificates</th>
 	          <th class="none" scope="col"></th>
 	        </tr>
 	      </thead>


### PR DESCRIPTION
This PR adds the "Uses approved certificates" column to the domains table & properly displays the subdomain/details drop down as yes & no. I also removed code related to the preloaded column since it is now replaced by "Uses approved certificates".

French table has English column names because we don't have translations yet.