### PR TITLE
Default span size

### DIFF
--- a/track/static/js/tables.js
+++ b/track/static/js/tables.js
@@ -93,6 +93,9 @@ var Tables = {
 
   // common render helper for percent bars
   percentBar: function(data) {
+    //values under 6 look weird, set default to 6
+    if(data > 0 && data < 6) data = 6;
+
     return '' +
       '<div class="progress-bar-indication">' +
         '<span class="meter width' + data + '" style="width: ' + data + '%">' +

--- a/track/static/js/tables.js
+++ b/track/static/js/tables.js
@@ -94,11 +94,12 @@ var Tables = {
   // common render helper for percent bars
   percentBar: function(data) {
     //values under 6 look weird, set default to 6
-    if(data > 0 && data < 6) data = 6;
+    if(data > 0 && data < 6) span_width = 6;
+    else span_width = data;
 
     return '' +
       '<div class="progress-bar-indication">' +
-        '<span class="meter width' + data + '" style="width: ' + data + '%">' +
+        '<span class="meter width' + span_width + '" style="width: ' + span_width + '%">' +
           '<p>' + data + '%</p>' +
         '</span>' +
       '</div>';


### PR DESCRIPTION
This PR modifies the percent bar function to default to 6 when the value is between 1-5. The idea is if this doesn't look too weird, it'll fix the weird span display for small values.

When reviewing this, if you could fire up the branch with your set of data and show me the result, that would be awesome!