### PR TITLE
Force columns to sort numeric

### DIFF
--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -41,14 +41,17 @@ $(function () {
         {data: "organization_name_" + language}, // here for filtering/sorting
         {
           data: "totals.https.enforces",
+          type: "numeric",
           render: Tables.percentTotals("https", "enforces")
         },
         {
           data: "totals.https.hsts",
+          type: "numeric",
           render: Tables.percentTotals("https", "hsts")
         },
         {
           data: "totals.crypto.bod_crypto",
+          type: "numeric",
           render: Tables.percentTotals("crypto", "bod_crypto")
         },
         {

--- a/track/static/js/https/organizations.js
+++ b/track/static/js/https/organizations.js
@@ -24,22 +24,27 @@ $(document).ready(function () {
         },
         {
           data: "https.compliant",
+          type: "numeric",
           render: Tables.percent("https", "compliant")
         },
         {
           data: "https.enforces",
+          type: "numeric",
           render: Tables.percent("https", "enforces")
         },
         {
           data: "https.hsts",
+          type: "numeric",
           render: Tables.percent("https", "hsts")
         },
         {
           data: "crypto.bod_crypto",
+          type: "numeric",
           render: Tables.percent("crypto", "bod_crypto")
         },
         {
           data: "crypto.good_cert",
+          type: "numeric",
           render: Tables.percent("crypto", "good_cert")
         },
       ]


### PR DESCRIPTION
This PR addresses issue https://github.com/cds-snc/track-web/issues/22. The "--" value in the table column caused the column to sort by string rather than numerically. Pulse addressed this by forcing the columns to sort numeric so I'm applying the same fix here. 