### PR TITLE
Verify dependency lists are synced

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
               . .env/bin/activate
               # pylint src tests -- Major overhaul needed to not fail linting, not including linting in tests for now
               # mypy src tests
+              ./utils/sync_dependencies.py setup.py requirements.txt
               pytest --cov=track tests
           name: "Running tests"
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ jobs:
           key: "deps1-{{ .Branch }}-{{ checksum \"requirements.txt\" }}"
       - run:
           command: |
+              ./utils/sync_dependencies.py setup.py requirements.txt
+          name: "Check dependency lists are synced"
+      - run:
+          command: |
               python3 -m venv .env
               . .env/bin/activate
               pip install -r requirements.txt
@@ -24,7 +28,6 @@ jobs:
               . .env/bin/activate
               # pylint src tests -- Major overhaul needed to not fail linting, not including linting in tests for now
               # mypy src tests
-              ./utils/sync_dependencies.py setup.py requirements.txt
               pytest --cov=track tests
           name: "Running tests"
     working_directory: ~/repo

--- a/utils/sync_dependencies.py
+++ b/utils/sync_dependencies.py
@@ -31,6 +31,7 @@ def extract_txt_requires(requirements_path: pathlib.Path) -> typing.Set[str]:
     with requirements_path.open('r', encoding='utf-8-sig') as req:
         requirements = set(line.rstrip('\n') for line in req.readlines())
         requirements.discard('-e .')
+        requirements.discard('')
         return requirements
 
 


### PR DESCRIPTION
This PR adds a line to CI to ensure that the dependency lists in `requirements.txt` and `setup.py` are synced.