### PR TITLE
Change from 100 entries per page to 25

### DIFF
--- a/track/static/js/tables.js
+++ b/track/static/js/tables.js
@@ -53,7 +53,7 @@ var Tables = {
 
     // Paginate to 100 per-page by default.
     if (!options.dom) options.dom = 'fCtrip';
-    if (!options.pageLength) options.pageLength = 100;
+    if (!options.pageLength) options.pageLength = 25;
 
     var table = $("table").DataTable(options);
 
@@ -69,7 +69,7 @@ var Tables = {
   // sets some organization-table-specific options
   initAgency: function(data, options) {
     // Don't paginate organization tables by default.
-    if (!options.pageLength) options.pageLength = 100;
+    if (!options.pageLength) options.pageLength = 25;
     if (!options.dom) options.dom = 'fCtrip';
 
     return Tables.init(data, options);


### PR DESCRIPTION
This PR addresses issue https://github.com/cds-snc/track-web/issues/8. It changes the maximum number of entries per page from 100 to 25.

Domains:
<img width="263" alt="screen shot 2018-06-20 at 7 41 43 pm" src="https://user-images.githubusercontent.com/1545806/41690122-1475a3e8-74c2-11e8-997c-78e894d1f10a.png">

Organization: 
<img width="285" alt="screen shot 2018-06-20 at 7 40 20 pm" src="https://user-images.githubusercontent.com/1545806/41690133-1beeb27c-74c2-11e8-8cc0-61c6b3778579.png">
