### PR TITLE
Add redirecting based on language header to index route

### DIFF
--- a/track/views.py
+++ b/track/views.py
@@ -1,5 +1,5 @@
 
-from flask import render_template, Response, abort, request
+from flask import render_template, Response, abort, request, redirect
 from track import models
 from track.data import FIELD_MAPPING
 import os
@@ -7,10 +7,15 @@ import ujson
 
 def register(app):
 
-    # Default route will be English index for now
+    # Default route checks accept-language header
+    # Redirects based on browser language, defaults to english
     @app.route("/")
     def index():
-        return render_template("en/index.html")
+        user_lang = request.headers.get("Accept-Language", "en")
+        if (user_lang[:2] == "fr"):
+            return redirect("/fr/index/")
+        else:
+            return redirect("/en/index/")
 
     @app.route("/en/")
     @app.route("/fr/")


### PR DESCRIPTION
This PR addresses issue https://github.com/cds-snc/track-web/issues/11 by checking the Accept-Language header when the user visits the index route of the app. If the language is FR, it'll redirect to the French index page. If it's anything else (or there is no language header), it'll redirect to the English index page. 