### PR TITLE
Fix singular subdomains

### DIFF
--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -92,7 +92,7 @@ $(function () {
     show: {
       en: "Show",
       fr: "Montrer les"
-    } , 
+    },
 
     hide: {
       en: "Hide",
@@ -147,7 +147,12 @@ $(function () {
     subdomains: {
       en: " subdomains",
       fr: " sous-domaines"
-    }
+    },
+
+    subdomain: {
+      en: " subdomain",
+      fr: " sous-domaine"
+    },
 
   };
 
@@ -295,6 +300,8 @@ $(function () {
   var showHideText = function(show, row) {
     if (loneDomain(row))
       return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + text.show[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + text.hide[language]) + " " + text.details[language];
+    else if(row.totals.https.eligible == 1)
+      return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + {en: "Show", fr: "Montrer le"}[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + {en: "Hide", fr: "Cacher le"}[language]) + " " + {en: "1", fr:""}[language] + text.subdomain[language];
     else
       return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + text.show[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + text.hide[language]) + " " + row.totals.https.eligible + text.subdomains[language];
   };


### PR DESCRIPTION
This PR addresses issue https://github.com/cds-snc/track-web/issues/5 by adding different text if the row count is 1 (if only one subdomain exists). 

English:
![screen shot 2018-06-21 at 2 21 17 pm](https://user-images.githubusercontent.com/1545806/41738025-04e837e0-755f-11e8-8f5a-b34ee680b102.png)
![screen shot 2018-06-21 at 2 21 22 pm](https://user-images.githubusercontent.com/1545806/41738026-05097b26-755f-11e8-809e-f3d57f3bfb50.png)

French:
![screen shot 2018-06-21 at 2 20 51 pm](https://user-images.githubusercontent.com/1545806/41738040-0c91387a-755f-11e8-9e9f-06c13fb73711.png)
![screen shot 2018-06-21 at 2 20 58 pm](https://user-images.githubusercontent.com/1545806/41738041-0ca5a53a-755f-11e8-9fd9-2e73ce37e691.png)

The rest of the text remains unchanged. 