### PR TITLE
remove text on badge line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CircleCI Status: [![CircleCI](https://circleci.com/gh/cds-snc/track-web.svg?style=svg)](https://circleci.com/gh/cds-snc/track-web)
+[![CircleCI](https://circleci.com/gh/cds-snc/track-web.svg?style=svg)](https://circleci.com/gh/cds-snc/track-web)
 [![Known Vulnerabilities](https://snyk.io/test/github/cds-snc/track-web/badge.svg)](https://snyk.io/test/github/cds-snc/track-web)
 
 


### PR DESCRIPTION
This PR removes the text preceeding the badges on the README.

With more than one badge, it is incorrect to say that the badges just represent "CircleCI Status".
I looked around on some other repositories and it seems to be common practice to simply list the badges on one line at the top of the README with no text.