### PR TITLE
move some dependencies to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cds-webkit-example",
+  "name": "track-web",
   "author": "Canadian Digital Service",
   "contributors": [
     "Dave Samojlenko <dave.samojlenko@cds-snc.ca"
@@ -9,7 +9,9 @@
     "dev": "gulp build && gulp watch:sass"
   },
   "dependencies": {
-    "cds-webkit": "^0.0.5",
+    "cds-webkit": "^0.0.5"
+  },
+  "devDependencies": {
     "del": "^3.0.0",
     "gulp": "^4.0.0",
     "gulp-notify": "^3.2.0",


### PR DESCRIPTION
a sub-dependency of gulp-watch was triggering a snyk alert.  moving it to devDependencies to address.