### PR TITLE
Change name of details csv

### DIFF
--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -243,7 +243,7 @@ $(function () {
     var all = [];
     var number = hosts.length;
 
-    var csv = "/data/hosts/" + base_domain + "/https.csv";
+    var csv = "/data/hosts/" + base_domain + "/compliance.csv";
 
     var link = text.link_1[language] + number + text.link_2[language] + base_domain + ".&nbsp;&nbsp;";
     link += l(csv, text.link_3[language] + base_domain + text.link_4[language]) + ".";

--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -7,7 +7,7 @@ $(function () {
   $.get("/data/domains/https.json", function(data) {
     table = Tables.init(data.data, {
 
-      csv: "/data/hosts/https.csv",
+      csv: "/data/hosts/compliance.csv",
 
       responsive: {
           details: {

--- a/track/static/js/https/organizations.js
+++ b/track/static/js/https/organizations.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
 
     Tables.initAgency(data.data, {
 
-      csv: "/data/hosts/https.csv",
+      csv: "/data/hosts/compliance.csv",
 
       prefix: language,
 

--- a/track/views.py
+++ b/track/views.py
@@ -74,6 +74,8 @@ def register(app):
     @app.route("/data/reports/<report_name>.json")
     @cache.cached()
     def report(report_name):
+        report_name = 'https' if report_name == 'compliance' else report_name
+
         response = Response(ujson.dumps(models.Report.latest().get(report_name, {})))
         response.headers['Content-Type'] = 'application/json'
         return response
@@ -82,6 +84,8 @@ def register(app):
     @app.route("/data/domains/<report_name>.<ext>")
     @cache.cached()
     def domain_report(report_name, ext):
+        report_name = 'https' if report_name == 'compliance' else report_name
+
         domains = models.Domain.eligible_parents(report_name)
         domains = sorted(domains, key=lambda k: k['domain'])
 
@@ -151,6 +155,8 @@ def register(app):
     @app.route("/data/hosts/<report_name>.<ext>")
     @cache.cached()
     def hostname_report(report_name, ext):
+        report_name = 'https' if report_name == 'compliance' else report_name
+
         domains = models.Domain.eligible(report_name)
 
         # sort by base domain, but subdomain within them
@@ -169,6 +175,8 @@ def register(app):
     @app.route("/data/hosts/<domain>/<report_name>.<ext>")
     @cache.cached()
     def hostname_report_for_domain(domain, report_name, ext):
+        report_name = 'https' if report_name == 'compliance' else report_name
+
         domains = models.Domain.eligible_for_domain(domain, report_name)
 
         # sort by hostname, but put the parent at the top if it exist
@@ -186,6 +194,8 @@ def register(app):
     @app.route("/data/organizations/<report_name>.json")
     @cache.cached()
     def organization_report(report_name):
+        report_name = 'https' if report_name == 'compliance' else report_name
+
         domains = models.Organization.eligible(report_name)
         response = Response(ujson.dumps({'data': domains}))
         response.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
This PR changes the name of the detailed information csv from `https.csv` to `compliance.csv` for clarity.

The old name, `https.csv` will still work, but the frontend will use the name `compliance.csv`