### PR TITLE
Google Analytics & Events

### DIFF
--- a/track/static/js/dataTables.downloads.js
+++ b/track/static/js/dataTables.downloads.js
@@ -36,7 +36,7 @@ $.fn.dataTable.Download = function ( inst ) {
     if (drawnOnce) return;
 
     var elem = "" +
-      "<a class=\"text-https-blue hover:text-black font-bold\" href=\"" + csv + "\" download>" +
+      "<a onClick=\"gtag('event', 'download', { event_category: 'Downloads', event_action: 'Download full CSV'});\" class=\"text-https-blue hover:text-black font-bold\" href=\"" + csv + "\" download>" +
         text +
       "</a>";
 

--- a/track/static/js/https/domains.js
+++ b/track/static/js/https/domains.js
@@ -269,7 +269,7 @@ $(function () {
     }
 
     var link = text.link_1[language] + number + text.link_2[language] + base_domain;
-    link += l(csv, text.link_3[language], "class=\"float-right mr-4\"");
+    link += l(base_domain, csv, text.link_3[language], "class=\"float-right mr-4\"");
 
     var download = $("<tr></tr>").addClass("subdomain").html("<td class=\"link bg-https-light-gray\" colspan=6><strong>" + link + "</strong></td>");
     all.push(download);
@@ -287,7 +287,7 @@ $(function () {
     // determines whether remote fetching has to happen
     var fetch = !(loneDomain(row));
 
-    return n(row.domain) + "<div class=\"mt-2\">" + l("#", showHideText(true, row), "onclick=\"return false\" data-fetch=\"" + fetch + "\" data-domain=\"" + row.domain + "\"") + "</div>";
+    return n(row.domain) + "<div class=\"mt-2\">" + l("", "#", showHideText(true, row), "onclick=\"return false\" data-fetch=\"" + fetch + "\" data-domain=\"" + row.domain + "\"") + "</div>";
   };
 
   var showHideText = function(show, row) {
@@ -368,7 +368,10 @@ $(function () {
     });
   };
 
-  var l = function(href, text, extra) {
+  var l = function(base_domain, href, text, extra) {
+    // if base domain is provided, CSV download, so track with gtag
+    if(base_domain != "") return "<a onClick=\"gtag('event', 'download', { event_category: 'Downloads', event_action: 'Download CSV for " + base_domain + "'});\" href=\"" + href + "\" target=\"blank\" " + extra + ">" + text + "</a>";
+    
     return "<a href=\"" + href + "\" target=\"blank\" " + extra + ">" + text + "</a>";
   };
 

--- a/track/static/js/https/organizations.js
+++ b/track/static/js/https/organizations.js
@@ -86,7 +86,7 @@ $(document).ready(function () {
 
     var link = function(link_text) {
       return "" +
-        "<a href=\"/" + language + "/" + text.domains[language] + "/#" +
+        "<a onClick=\"gtag('event', 'Search', { event_category: 'Search for Organization', event_action: 'Search for " + row["name_" + language] + " domains'});\" href=\"/" + language + "/" + text.domains[language] + "/#" +
           QueryString.stringify({q: row["name_" + language]}) + "\">" +
            link_text +
         "</a>";

--- a/track/templates/includes/head.html
+++ b/track/templates/includes/head.html
@@ -25,6 +25,15 @@
 <script src="/static/js/vendor/querystring.js"></script>
 <script src="/static/js/utils.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script>
 
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-102484926-7"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-102484926-7');
+</script>
 
 <!-- sigh, datatables -->
 


### PR DESCRIPTION
I call this Google Analytics 2 Electric Boogaloo. This PR adds gtag.js & custom event calls to track usage of track-web. Client will need to create their own google analytics account and swap out the ID in the head code, which will be documented. 

![screen shot 2018-06-28 at 3 03 49 pm](https://user-images.githubusercontent.com/1545806/42057910-c83d3ab4-7aec-11e8-97d9-fb3b4c899edf.png)
![screen shot 2018-06-28 at 3 22 27 pm](https://user-images.githubusercontent.com/1545806/42057925-d247fe5e-7aec-11e8-83fc-edcb0ddc21e8.png)
