### PR TITLE
fix missed unused argument

### DIFF
--- a/track/views.py
+++ b/track/views.py
@@ -83,7 +83,7 @@ def register(app):
     # Detailed data per-parent-domain.
     @app.route("/data/domains/<report_name>.json")
     @cache.cached()
-    def domain_report(report_name, ext):
+    def domain_report(report_name):
         report_name = 'https' if report_name == 'compliance' else report_name
 
         domains = models.Domain.eligible_parents(report_name)


### PR DESCRIPTION
In #51 an unused argument was missed when separating the csv and json routes.
This causes an exception to be raised when attempting to access the domains report.

This PR fixes that issue