### PR TITLE
Menu improvements on smaller screens

### DIFF
--- a/track/static/js/tables.js
+++ b/track/static/js/tables.js
@@ -167,7 +167,7 @@ $(function() {
     // add custom tailwind classes
     $('#DataTables_Table_0_filter').attr('class', 'flex block justify-start md:justify-center');
     $('#DataTables_Table_0_filter label').attr('class', 'w-full md:w-2/3');
-    $('#datatables-search').attr('class', 'border border-solid border-https-dark-gray bg-https-light-gray focus:border-https-blue block md:inline-block h-8 md:ml-6 mb-4 md:mb-8 w-full md:w-4/5');
+    $('#datatables-search').attr('class', 'border border-solid border-https-dark-gray bg-https-light-gray focus:border-https-blue block md:inline-block h-8 md:ml-6 mb-4 md:mb-8 w-full md:w-3/5 lg:w-3/4');
     $('.dataTables_csv').attr('class', 'text-lg md:ml-4 mt-4 md:mt-6');
   });
 });

--- a/track/templates/en/layout-en.html
+++ b/track/templates/en/layout-en.html
@@ -42,21 +42,21 @@
 	     <nav class="bg-white border-b border-https-dark-gray">
 			<div class="container mx-auto flex">
 				<div class="{{ self.pageid_fr() | site_title(false) }}">
-					<h2 class="py-6 text-lg sm:text-xl hidden sm:block"><a class="text-grey-darkest no-underline font-medium hover:text-https-blue" href="/en/index/">Track web security compliance</a></h2>
+					<h2 class="py-6 text-base sm:text-lg hidden md:block"><a class="text-grey-darkest no-underline font-medium hover:text-https-blue" href="/en/index/">Track web security compliance</a></h2>
 				</div>
 		        <div role="navigation" class="flex-1">
-		            <ul class="list-reset flex justify-end text-lg sm:text-xl font-normal">
-		                <li class="py-6 inline sm:hidden">
-		                    <a id="menu-btn" class="text-https-blue no-underline hover:underline" href="#">Menu</a>
+		            <ul class="list-reset flex justify-end text-base sm:text-lg font-normal">
+		                <li class="py-6 inline lg:hidden">
+		                    <a id="menu-btn" class="text-https-blue hover:text-black no-underline hover:underline" href="#">Menu</a>
 		                </li>
-		                 <li class="mr-8 py-6 hidden sm:flex">
-		                    <a class="text-https-blue no-underline hover:underline" href="/en/organizations/">Check compliance</a>
+		                 <li class="mr-8 py-6 hidden lg:flex">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/organizations/">Check compliance</a>
 		                </li>
-		                <li class="mr-8 py-6 hidden sm:flex">
-		                    <a class="text-https-blue no-underline hover:underline" href="/en/guidance/">Read guidance</a>
+		                <li class="mr-8 py-6 hidden lg:flex">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/guidance/">Read guidance</a>
 		                </li>
-		                <li class="py-6 hidden sm:flex">
-		                    <a class="text-https-blue no-underline hover:underline" href="/en/help/">Get help</a>
+		                <li class="py-6 hidden lg:flex">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/help/">Get help</a>
 		                </li>
 		            </ul>
 		        </div>
@@ -65,11 +65,11 @@
 
 	     <nav id="menu-content" class="shadow-md">
 		    <ul class="list-reset ml-4 mr-2 mt-4 font-normal">
-		        <li class="{{ self.pageid_fr() | site_title(true) }} block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/index/">Track web security compliance</a></li>
-		        <li class="block border-b border-https-dark-gray py-4"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/organizations/">Check compliance</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/guidance/">Read guidance</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/help/">Get help</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/{{ self.pageid_fr() }}" lang="fr">Français</a></li>
+		        <li class="{{ self.pageid_fr() | site_title(true) }} block py-4 border-b border-https-dark-gray sm:block md:hidden"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/index/">Track web security compliance</a></li>
+		        <li class="block border-b border-https-dark-gray py-4"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/en/organizations/">Check compliance</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/en/guidance/">Read guidance</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/en/help/">Get help</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray sm:hidden"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/fr/{{ self.pageid_fr() }}" lang="fr">Français</a></li>
 		    </ul>
 		</nav>
 

--- a/track/templates/en/layout-en.html
+++ b/track/templates/en/layout-en.html
@@ -46,16 +46,16 @@
 				</div>
 		        <div role="navigation" class="flex-1">
 		            <ul class="list-reset flex justify-end text-base sm:text-lg font-normal">
-		                <li class="py-6 inline lg:hidden">
+		                <li class="py-6 inline xl:hidden">
 		                    <a id="menu-btn" class="text-https-blue hover:text-black no-underline hover:underline" href="#">Menu</a>
 		                </li>
-		                 <li class="mr-8 py-6 hidden lg:flex">
+		                 <li class="mr-8 py-6 hidden xl:flex">
 		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/organizations/">Check compliance</a>
 		                </li>
-		                <li class="mr-8 py-6 hidden lg:flex">
+		                <li class="mr-8 py-6 hidden xl:flex">
 		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/guidance/">Read guidance</a>
 		                </li>
-		                <li class="py-6 hidden lg:flex">
+		                <li class="py-6 hidden xl:flex">
 		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/en/help/">Get help</a>
 		                </li>
 		            </ul>

--- a/track/templates/fr/layout-fr.html
+++ b/track/templates/fr/layout-fr.html
@@ -42,21 +42,21 @@
 	    <nav class="bg-white border-b border-https-dark-gray">
 			<div class="container mx-auto flex">
 				<div class="{{ self.pageid_en() | site_title(false) }}">
-					<h2 class="py-6 text-lg sm:text-xl hidden sm:block"><a class="text-grey-darkest no-underline font-medium hover:text-https-blue" href="/fr/index/">Suivre la conformité en matière de sécurité Web</a></h2>
+					<h2 class="py-6 text-base sm:text-lg hidden md:block"><a class="text-grey-darkest no-underline font-medium hover:text-https-blue" href="/fr/index/">Suivre la conformité en matière de sécurité Web</a></h2>
 				</div>
 		        <div role="navigation" class="flex-1">
-		            <ul class="list-reset flex justify-end text-lg sm:text-xl font-normal">
-		                <li class="py-6 inline sm:hidden">
-		                    <a id="menu-btn" class="text-https-blue no-underline hover:underline" href="#">Menu</a>
+		            <ul class="list-reset flex justify-end text-base sm:text-lg font-normal">
+		                <li class="py-6 md:py-8 lg:py-6 inline xl:hidden">
+		                    <a id="menu-btn" class="text-https-blue hover:text-black no-underline hover:underline" href="#">Menu</a>
 		                </li>
-		                <li class="mr-8 py-6 hidden sm:inline">
-		                    <a class="text-https-blue no-underline hover:underline" href="/fr/organisations/">Vérifier la conformité</a>
+		                <li class="mr-8 py-6 hidden xl:inline">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/fr/organisations/">Vérifier la conformité</a>
 		                </li>
-		                <li class="mr-8 py-6 hidden sm:inline">
-		                    <a class="text-https-blue no-underline hover:underline" href="/fr/directives/">Lire les directives</a>
+		                <li class="mr-8 py-6 hidden xl:inline">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/fr/directives/">Lire les directives</a>
 		                </li>
-		                <li class="py-6 hidden sm:inline">
-		                    <a class="text-https-blue no-underline hover:underline" href="/fr/aide/">Obtenir de l’aide</a>
+		                <li class="py-6 hidden xl:inline">
+		                    <a class="text-https-blue hover:text-black no-underline hover:underline" href="/fr/aide/">Obtenir de l’aide</a>
 		                </li>
 		            </ul>
 		        </div>
@@ -65,11 +65,11 @@
 
 	    <nav id="menu-content" class="shadow-md">
 		    <ul class="list-reset ml-4 mr-2 mt-4">
-		    	<li class="{{ self.pageid_en() | site_title(true) }} block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/index/">Suivre la conformité en matière de sécurité Web</a></li>
-		    	<li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/organisations/">Vérifier la conformité</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/directives/">Lire les directives</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/aide/">Obtenir de l’aide</a></li>
-		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/en/{{ self.pageid_en() }}" lang="en">English</a></li>
+		    	<li class="{{ self.pageid_en() | site_title(true) }} block py-4 border-b border-https-dark-gray sm:block md:hidden"><a tabindex="-1" class="text-xl text-https-blue no-underline hover:underline" href="/fr/index/">Suivre la conformité en matière de sécurité Web</a></li>
+		    	<li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/fr/organisations/">Vérifier la conformité</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/fr/directives/">Lire les directives</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/fr/aide/">Obtenir de l’aide</a></li>
+		        <li class="block py-4 border-b border-https-dark-gray sm:hidden"><a tabindex="-1" class="text-xl text-https-blue hover:text-black no-underline hover:underline" href="/en/{{ self.pageid_en() }}" lang="en">English</a></li>
 		    </ul>
 		</nav>
 


### PR DESCRIPTION
This PR changes the breakpoints where the menu collapses into mobile mode, for better display on medium/ipad sized screens. 

![screen shot 2018-06-29 at 12 16 43 pm](https://user-images.githubusercontent.com/1545806/42103203-5c2c81f4-7b96-11e8-884c-849e45fe3c56.png)
![screen shot 2018-06-29 at 12 16 59 pm](https://user-images.githubusercontent.com/1545806/42103210-5fe5e68c-7b96-11e8-8660-c60a642f3445.png)
