### PR TITLE
Check a government website link change

### DIFF
--- a/track/templates/en/index.html
+++ b/track/templates/en/index.html
@@ -17,7 +17,7 @@
 				<p class="text-xl">Canadians rely on the Government of Canada to provide secure digital services. A <a class="text-https-blue hover:text-black font-bold" href="https://www.canada.ca/en/treasury-board-secretariat/services/information-technology/policy-implementation-notices/implementing-https-secure-web-connections-itpin.html">new policy notice</a> guides government websites to adopt good web security practices. Track how government sites are becoming more secure.</p>
 
 				<div class="flex">
-					<p class="text-xl mt-2 lg:mt-6"><a href="/en/organizations/" class="text-https-blue hover:text-black font-bold">Check a government website</a></p>
+					<p class="text-xl mt-2 lg:mt-6"><a href="/en/domains/" class="text-https-blue hover:text-black font-bold">Check a government website</a></p>
 					<object class="ml-2 lg:mt-4" type="image/svg+xml" tabindex="-1" aria-hidden="true" role="none" data="/static/images/cta-arrow.svg"></object>
 				</div>
 

--- a/track/templates/fr/index.html
+++ b/track/templates/fr/index.html
@@ -17,7 +17,7 @@
 				<p class="text-xl">Les Canadiens s'attendent à ce que le gouvernement du Canada leur offre des services en ligne sécurisés. Un <a class="text-https-blue hover:text-black font-bold" href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/technologie-information/avis-mise-oeuvre-politique/mise-oeuvre-https-connexions-web-securisees-ampti.html">nouvel avis de politique</a> vise à assurer que les sites gouvernementaux soient conformes aux bonnes pratiques en matière de sécurité Web. Voyez comment les sites gouvernementaux deviennent plus sécuritaires.</p>
 
 				<div class="flex">
-					<p class="text-xl mt-2 lg:mt-6"><a href="/fr/organisations/" class="text-https-blue hover:text-black font-bold">Vérifier la conformité d’un site gouvernemental</a></p>
+					<p class="text-xl mt-2 lg:mt-6"><a href="/fr/domaines/" class="text-https-blue hover:text-black font-bold">Vérifier la conformité d’un site gouvernemental</a></p>
 					<object class="ml-2 lg:mt-4" type="image/svg+xml" tabindex="-1" role="img" aria-hidden="true" data="/static/images/cta-arrow.svg"></object>
 				</div>
 


### PR DESCRIPTION
This PR will change the link from "Check a government website" so the user lands on the domain table instead of the organization table, and they can actually search for a site. 