### PR TITLE
Health check

### DIFF
--- a/track/views.py
+++ b/track/views.py
@@ -23,7 +23,7 @@ def register(app):
 
     @app.route("/ping")
     def health_check():
-        return 'PONG' # We Redis now
+        return 'PONG'
 
     @app.route("/en/")
     @app.route("/fr/")

--- a/track/views.py
+++ b/track/views.py
@@ -21,6 +21,10 @@ def register(app):
         else:
             return redirect("/en/index/")
 
+    @app.route("/ping")
+    def health_check():
+        return 'PONG' # We Redis now
+
     @app.route("/en/")
     @app.route("/fr/")
     @app.route("/en/index/")


### PR DESCRIPTION
This PR adds a `/ping` route that simply responds with a static message

This simple route is meant to be used in health checks to verify the service is still running.