### PR TITLE
add app error handler for PyMongo Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ click==6.7
 gevent==1.2.2
 Babel==2.6.0
 Flask-Caching==1.4.0
+pymongo==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
         'gunicorn==19.6.0',
         'pyyaml==3.12',
         'python-slugify==1.2.1',
+        'pymongo==3.7.0',
         'Flask-PyMongo==0.5.1',
         'ujson==1.35',
         'flask-compress==1.4.0',

--- a/track/models.py
+++ b/track/models.py
@@ -3,6 +3,7 @@ import datetime
 import csv
 import typing
 from flask_pymongo import PyMongo
+from pymongo.errors import PyMongoError
 import track.data
 
 # These functions are meant to be the only ones that access the g.db.db
@@ -10,6 +11,8 @@ import track.data
 # coordinated here.
 
 db = PyMongo()
+
+QueryError = PyMongoError
 
 # Data loads should clear the entire database first.
 def clear_database():

--- a/track/views.py
+++ b/track/views.py
@@ -241,5 +241,10 @@ def register(app):
         return render_template("feed.xml")
 
     @app.errorhandler(404)
-    def page_not_found(e):
+    def page_not_found(error):
+        return render_template('404.html'), HTTPStatus.NOT_FOUND
+
+    @app.errorhandler(models.QueryError)
+    def handle_invalid_usage(error):
+        app.logger.error(error)
         return render_template('404.html'), HTTPStatus.NOT_FOUND


### PR DESCRIPTION
These errors typically should only come up if a user attempts to
manually visit a malformed /data/ endpoint, but sending back a 404 seems
a better solution than a 500.