### PR TITLE
Cache busting

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -378,3 +378,15 @@ class TestOrganizations():
         clean_model.Organization.create(organization)
         all_organizations = [organization for organization in clean_model.Organization.all()]
         assert len(all_organizations) == 2
+
+
+class TestFlag():
+
+    def test_get_cache_not_set(self, clean_model) -> None: # pylint: disable=no-self-use
+        assert not clean_model.Flag.get_cache()
+
+    def test_get_cache_set(self, clean_model) -> None: # pylint: disable=no-self-use
+        clean_model.Flag.set_cache(True)
+        assert clean_model.Flag.get_cache()
+        clean_model.Flag.set_cache(False)
+        assert not clean_model.Flag.get_cache()

--- a/track/models.py
+++ b/track/models.py
@@ -288,10 +288,7 @@ class Flag:
     @staticmethod
     def get_cache() -> bool:
         flags = db.db.meta.find_one({"_collection": "flags"})
-        if flags:
-            return flags['cache']
-        else:
-            Flag.set_cache(True)
+        return flags['cache'] if flags else False
 
     @staticmethod
     def set_cache(state: bool) -> None:

--- a/track/models.py
+++ b/track/models.py
@@ -281,3 +281,19 @@ class Organization:
     @staticmethod
     def all() -> typing.Iterable[typing.Dict]:
         return db.db.meta.find({'_collection': 'organizations'}, {'_id': False, '_collection': False})
+
+
+class Flag:
+
+    @staticmethod
+    def get_cache() -> bool:
+        flags = db.db.meta.find_one({"_collection": "flags"})
+        if flags:
+            return flags['cache']
+        else:
+            Flag.set_cache(True)
+
+    @staticmethod
+    def set_cache(state: bool) -> None:
+        db.db.meta.update_one({"_collection": "flags"}, {"$set": {"cache": state}}, upsert=True)
+

--- a/track/views.py
+++ b/track/views.py
@@ -239,11 +239,6 @@ def register(app):
         response.headers['Content-Type'] = 'application/json'
         return response
 
-    # Sanity-check RSS feed, shows the latest report.
-    @app.route("/data/reports/feed/")
-    def report_feed():
-        return render_template("feed.xml")
-
     @app.errorhandler(404)
     def page_not_found(error):
         return render_template('404.html'), HTTPStatus.NOT_FOUND
@@ -252,3 +247,10 @@ def register(app):
     def handle_invalid_usage(error):
         app.logger.error(error)
         return render_template('404.html'), HTTPStatus.NOT_FOUND
+
+    @app.before_request
+    def verify_cache():
+        if not models.Flag.get_cache():
+            app.logger.info('Clearing cache...')
+            cache.clear()
+            models.Flag.set_cache(True)


### PR DESCRIPTION
This PR adds support for a flag to drop the cache, mirroring https://github.com/cds-snc/tracker/pull/34

This will allow the scan to signal the tracker that the cache is now invalid, to let the data be as up to date as possible.