### PR TITLE
Re-add response to QueryError handler

### DIFF
--- a/track/views.py
+++ b/track/views.py
@@ -251,6 +251,7 @@ def register(app):
     @app.errorhandler(models.QueryError)
     def handle_invalid_usage(error):
         app.logger.error(error)
+        return render_template("404.html"), HTTPStatus.NOT_FOUND
 
     @app.before_request
     def verify_cache():


### PR DESCRIPTION
While resolving merge conflicts in #77 the response to the QueryError handler was accidentally removed, this PR adds it back.