### PR TITLE
cast the cache timeout to an int

### DIFF
--- a/track/config.py
+++ b/track/config.py
@@ -17,8 +17,8 @@ A_DAY = 60 * 60 * 24
 class ProductionConfig(Config):
     MONGO_URI = os.environ.get("TRACKER_MONGO_URI", None)
     CACHE_TYPE = "filesystem"
-    CACHE_DIR = os.environ.get("TRACKER_CACHE_DIR", ".")
-    CACHE_DEFAULT_TIMEOUT = os.environ.get("TRACKER_CACHE_TIMEOUT", A_DAY)
+    CACHE_DIR = os.environ.get("TRACKER_CACHE_DIR", "./.cache")
+    CACHE_DEFAULT_TIMEOUT = int(os.environ.get("TRACKER_CACHE_TIMEOUT", A_DAY))
 
     @staticmethod
     def init_app(app):

--- a/track/views.py
+++ b/track/views.py
@@ -1,10 +1,9 @@
-from flask import render_template, Response, abort, request, redirect
-from track import models
-from track.data import FIELD_MAPPING
 from http import HTTPStatus
 import os
-from flask import render_template, Response, abort, request
+
+from flask import render_template, Response, abort, request, redirect
 import ujson
+
 from track.data import FIELD_MAPPING
 from track import models
 from track.cache import cache


### PR DESCRIPTION
This PR just contains a bit of cleanup for configuration and imports

The filesystem cache that the prod config uses should be given it's own folder, as if it is not it is liable to delete non-cache files int he directory, so the default config now uses a .cache directory

The default timeout needs to be an int, so if the timeout is set via environment we'll need to cast it.