### PR TITLE
bump flask version to fix CVE-2018-1000656

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask==0.12
+flask==0.12.4
 gunicorn==19.6.0
 pyyaml==3.12
 python-slugify==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'flask==0.12',
+        'flask==0.12.4',
         'gunicorn==19.6.0',
         'pyyaml==3.12',
         'python-slugify==1.2.1',


### PR DESCRIPTION
This PR bumps the flask version to 0.12.4 to remove the vulnerability in flask present pre 0.12.3