### PR TITLE
Add query hash to csv url

### DIFF
--- a/track/static/js/dataTables.downloads.js
+++ b/track/static/js/dataTables.downloads.js
@@ -8,52 +8,58 @@
  *   } );
  */
 
-(function(window, document, $, undefined) {
+(function (window, document, $, undefined) {
 
 
-$.fn.dataTable.Download = function ( inst ) {
-  var api = new $.fn.dataTable.Api( inst );
-  var settings = api.settings()[0];
+  $.fn.dataTable.Download = function (inst) {
+    var api = new $.fn.dataTable.Api(inst);
+    var settings = api.settings()[0];
 
-  var csv = settings.oInit.csv;
+    var csv = settings.oInit.csv;
 
-  var container = $('<div></div>').addClass( 'dataTables_csv' );
-  var drawnOnce = false;
+    var container = $('<div></div>').addClass('dataTables_csv');
+    var drawnOnce = false;
 
-  var language = $( "table" ).attr("language");
+    var language = $("table").attr("language");
 
-  if(language == 'en')
-    var text = "Download as CSV"
-  else
-    var text = "Télécharger en tant que fichier CSV"
+    if (language == 'en')
+      var text = "Download as CSV"
+    else
+      var text = "Télécharger en tant que fichier CSV"
 
-  // API so the feature wrapper can return the node to insert
-  this.container = function () {
-    return container[0];
+    // API so the feature wrapper can return the node to insert
+    this.container = function () {
+      return container[0];
+    };
+
+    api.on('draw', function () {
+      var link = csv
+      var hash = window.location.hash
+      if (window.location.hash) {
+        link += "?query="+ encodeURI(hash.substring(3))
+      }
+
+      if (drawnOnce) return;
+
+      var elem = "" +
+        "<a onClick=\"gtag('event', 'download', { event_category: 'Download / Télécharger', event_action: 'Download / Télécharger CSV'});\" class=\"text-https-blue hover:text-black font-bold\" href=\"" + link + "\" download>" +
+        text +
+        "</a>";
+
+      container.html(elem);
+      drawnOnce = true;
+    });
   };
 
-  api.on('draw', function () {
-    if (drawnOnce) return;
-
-    var elem = "" +
-      "<a onClick=\"gtag('event', 'download', { event_category: 'Download / Télécharger', event_action: 'Download / Télécharger CSV'});\" class=\"text-https-blue hover:text-black font-bold\" href=\"" + csv + "\" download>" +
-        text +
-      "</a>";
-
-    container.html(elem);
-    drawnOnce = true;
+  // Subscribe the feature plug-in to DataTables, ready for use
+  $.fn.dataTable.ext.feature.push({
+    "fnInit": function (settings) {
+      var l = new $.fn.dataTable.Download(settings);
+      return l.container();
+    },
+    "cFeature": "C",
+    "sFeature": "Downloads"
   });
-};
-
-// Subscribe the feature plug-in to DataTables, ready for use
-$.fn.dataTable.ext.feature.push( {
-  "fnInit": function( settings ) {
-    var l = new $.fn.dataTable.Download(settings);
-    return l.container();
-  },
-  "cFeature": "C",
-  "sFeature": "Downloads"
-} );
 
 
 })(window, document, jQuery);


### PR DESCRIPTION
This adds the value from the datatables search to the csv download url (link)

This would be part 1 of issue https://github.com/cds-snc/track-web/issues/98
> should be as simple as updating the 'download csv' link with the data from search bar 

<hr>

The value will be available as ?query=keyword

<img width="534" alt="query-parms" src="https://user-images.githubusercontent.com/62242/50777363-5ba64480-1269-11e9-9782-304bfa213ee9.png">

Note: To handle this all client side is possible but would involve updating a bunch of the Datatables setup code and possibly adding a new plugin.



