### PR TITLE
Make google analytics code based on an environment variable

### DIFF
--- a/track/helpers.py
+++ b/track/helpers.py
@@ -1,6 +1,7 @@
 import pkg_resources
 import yaml
 import datetime
+import os
 from track import models
 from track.data import FIELD_MAPPING
 from babel.dates import format_date
@@ -56,3 +57,8 @@ def register(app):
     @app.template_filter("percent_not")
     def percent_not(num, denom):
         return (100 - round((num / denom) * 100))
+
+    @app.template_filter("fetch_env")
+    def fetch_env(value):
+        return os.getenv(value)
+

--- a/track/templates/includes/head.html
+++ b/track/templates/includes/head.html
@@ -1,3 +1,4 @@
+{% set GA_key = "GOOGLE_ANALYTICS" | fetch_env() %}
 
 <!-- Basic Page Needs
 ================================================== -->
@@ -22,14 +23,16 @@
 <script src="/static/js/vendor/querystring.js"></script>
 <script src="/static/js/utils.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-102484926-7"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-102484926-7');
-</script>
+{% if GA_key %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_key }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ GA_key }}');
+    </script>
+{% endif %}
 
 <!-- sigh, datatables -->
 


### PR DESCRIPTION
This PR fixes the issue where anyone running this project locally would return data to our analytics account (https://github.com/cds-snc/track-web/issues/120) by adding an environment variable for the google analytics tag. If the environment variable isn't set, the GA script won't be inserted. If the environment variable is set, the GA script will be inserted with the correct GA tag for the account it should be sending data back to. 

If you are deploying this app and wish to set up GA, you will need to set the GOOGLE_ANALYTICS environment to the value google provides you when you set up the analytics project, ex: UA-XXXXXXXXX-X