### PR TITLE
Google Analytics fixes

### DIFF
--- a/docs/en/google-analytics.md
+++ b/docs/en/google-analytics.md
@@ -1,6 +1,6 @@
 # Google Analytics
 
-This project includes a Google Analytics set up with custom events for CSV downloads and clicking Organization links, to track what data users are looking at/searching for. To make use of Google Analytics, you will have to create your own Google Analytics account and plug your new tracking ID in the `gtag('config')` function in `templates/includes/head.html`. Everything else should work automatically.
+This project includes a Google Analytics set up with custom events for CSV downloads and clicking Organization links, to track what data users are looking at/searching for. To make use of Google Analytics, you will have to create your own Google Analytics account and set your tracking ID as an environment variable during deployment, `GOOGLE_ANALYTICS` (e.g. `export GOOGLE_ANALYTICS=UA-XXXXXXXXX-X` to run locally). If you want to send analytics data to a second Google Analytics account, use the `GOOGLE_ANALYTICS_SECONDARY` environment variable. Everything else should work automatically.
 
 Two custom events are included to help track how users are interacting with the product. You can find these custom events under the `Behavior > Events` tab.
 

--- a/track/helpers.py
+++ b/track/helpers.py
@@ -1,6 +1,7 @@
 import pkg_resources
 import yaml
 import datetime
+import os
 from track import models
 from track.data import FIELD_MAPPING
 from babel.dates import format_date
@@ -56,3 +57,8 @@ def register(app):
     @app.template_filter("percent_not")
     def percent_not(num, denom):
         return (100 - round((num / denom) * 100))
+
+    @app.template_filter("fetch_env")
+    def fetch_env(value):
+        return os.getenv(value)
+

--- a/track/templates/includes/head.html
+++ b/track/templates/includes/head.html
@@ -1,4 +1,5 @@
 {% set GA_key = "GOOGLE_ANALYTICS" | fetch_env() %}
+{% set GA_key_secondary = "GOOGLE_ANALYTICS_SECONDARY" | fetch_env() %}
 
 <!-- Basic Page Needs
 ================================================== -->
@@ -31,6 +32,10 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', '{{ GA_key }}');
+
+      {% if GA_key_secondary %}
+      gtag('config', '{{ GA_key_secondary }}');
+      {% endif %}
     </script>
 {% endif %}
 

--- a/track/templates/includes/head.html
+++ b/track/templates/includes/head.html
@@ -31,10 +31,10 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', '{{ GA_key }}');
+      gtag('config', '{{ GA_key }}', { 'anonymize_ip': true });
 
       {% if GA_key_secondary %}
-      gtag('config', '{{ GA_key_secondary }}');
+      gtag('config', '{{ GA_key_secondary }}', { 'anonymize_ip': true });
       {% endif %}
     </script>
 {% endif %}

--- a/track/templates/includes/head.html
+++ b/track/templates/includes/head.html
@@ -1,3 +1,4 @@
+{% set GA_key = "GOOGLE_ANALYTICS" | fetch_env() %}
 
 <!-- Basic Page Needs
 ================================================== -->
@@ -22,14 +23,16 @@
 <script src="/static/js/vendor/querystring.js"></script>
 <script src="/static/js/utils.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-102484926-7"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-102484926-7');
-</script>
+{% if GA_key %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_key }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ GA_key }}');
+    </script>
+{% endif %}
 
 <!-- sigh, datatables -->
 


### PR DESCRIPTION
Building on @evadb’s work in #122 (I started from that branch and added a few more commits):

* Set Google Analytics tracking ID(s) via environment variables
* Allow for a second tracking ID
* Enable Google Analytics IP anonymization
* Document the shift to environment variables for Google Analytics

To your point, @sayaHub, that JS errors will be thrown if the Google Analytics environment variable isn’t set, a few points:

* The current deployment of the site, with the analytics code commented out, is throwing the same errors; if Google Analytics is enabled, the error’s won’t be thrown
* Those errors probably aren’t showstoppers in modern browsers, but you could test to determine whether it affects the browsers you support
* If you’d really like to suppress those errors, you could define dummy JavaScript functions for the Google Analytics functions called in the `onClick` handlers

I’ll leave it to you to determine which route you’d rather take for resolving those errors.

Note: Because I edited the English documentation to do this, I recommend translating the French equivalent of the file I edited, at your earliest convenience.