### PR TITLE
Compatibility with kubernetes 

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -7,4 +7,5 @@ workflow "CI" {
 
 action "Dockerfile lint" {
   uses = "docker://cdssnc/docker-lint"
+  args = "--ignore DL3013"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,10 @@
+workflow "CI" {
+  on = "push"
+  resolves = [
+    "Dockerfile lint"
+  ]
+}
+
+action "Dockerfile lint" {
+  uses = "docker://cdssnc/docker-lint"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.5 as python-base
-MAINTAINER David Buckley <david.buckley@cds-snc.ca>
 LABEL Description="Track Web Security Compliance" Vendor="Canadian Digital Service"
 
 COPY requirements.txt /opt/track-web/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,19 @@
+FROM python:3.5 as python-base
 MAINTAINER David Buckley <david.buckley@cds-snc.ca>
 LABEL Description="Track Web Security Compliance" Vendor="Canadian Digital Service"
 
-FROM python:3.5 as python-base
 COPY requirements.txt /opt/track-web/requirements.txt
 COPY setup.py /opt/track-web/setup.py 
 COPY track /opt/track-web/track
 COPY MANIFEST.in /opt/track-web/MANIFEST.in
 
-# Build wheels to install into production image
-# Force a build with --no-binary to get around the case where a wheel is available for python:3.5 but not python:3.5-alpine
 RUN pip install --upgrade pip && mkdir wheels && pip wheel --no-binary :all: -r /opt/track-web/requirements.txt -w wheels && pip wheel --no-deps /opt/track-web/ -w wheels
-
-FROM python:3.5-alpine
-MAINTAINER David Buckley <david.buckley@cds-snc.ca>
-LABEL Description="Track Digital Security Compliance" Vendor="Canadian Digital Service"
- 
-COPY --from=python-base /wheels /wheels
  
 RUN pip install /wheels/* && rm -rf /wheels /root/.cache/pip && \
-    addgroup -S track-web && adduser -S -G track-web track-web && \
+    addgroup --system track-web && adduser --system --group track-web && \
     mkdir -p /opt/track-web/.cache && \
     chown -R track-web /opt/track-web
+    
 USER track-web:track-web
  
 EXPOSE 5000

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-FROM ubuntu:16.04
-
-COPY deploy/provision.sh /opt/provision.sh
-RUN sh /opt/provision.sh
-
-COPY deploy/build-env.sh /opt/build-env.sh
-CMD ["sh", "/opt/build-env.sh", "/opt/apps/track-web"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3'
-services:
-    build-env:
-        build:
-            context: .
-            dockerfile: Dockerfile.build
-        volumes:
-         - .:/opt/apps/track-web/

--- a/track/config.py
+++ b/track/config.py
@@ -13,7 +13,7 @@ A_DAY = 60 * 60 * 24
 class Config:
     DEBUG = False
     TESTING = False
-    MONGO_URI = "mongodb://localhost:27017/track"
+    MONGO_URI = os.environ.get("TRACKER_MONGO_URI", "mongodb://localhost:27017/track")
     CACHE_TYPE = "null"
 
     @staticmethod


### PR DESCRIPTION
This PR makes small changes to the Docker file and the application code to allow it to be run as part of kubernetes set up. It also includes a workflow file to move to GitHub CI vs. Circle CI

**Dockerfile**
Removed the swarm and `.build` dockerfile. Also the new code additions surrounding Azure KeyStore require glibc libraries (crypto) that are no included in the Alpine base image, as a result, a debian based image is required. 

**Code changes**
Allowed for an environment variable `TRACKER_MONGO_URI` to be set that overrides the local dev environment. 
